### PR TITLE
feat: add automated testing infrastructure, code cleanup, and update default model 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ dist/
 build/
 *.tsbuildinfo
 
+# AI/Claude working directories
+.ai/
+.claude/
+
 
 
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,19 @@
+# Dependencies
+node_modules/
+
+# AI/Claude directories
+.ai/
+.claude/
+
+# Build artifacts
+dist/
+coverage/
+
+# Cache
+.pytest_cache/
+
+# Lock files
+package-lock.json
+
+# Logs
+*.log

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Visit [OpenRouter](https://openrouter.ai/) and get a key to use as a fallback pr
 You can set this key in your MCP settings under OPENROUTER_API_KEY, and it will trigger automatically if anything goes wrong with calling Cerebras.
 
 
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CEREBRAS_API_KEY` | Your Cerebras API key (required) | - |
+| `CEREBRAS_MODEL` | Cerebras model to use | `zai-glm-4.6` |
+| `OPENROUTER_API_KEY` | OpenRouter API key (optional fallback) | - |
+| `OPENROUTER_MODEL` | OpenRouter model to use | `qwen/qwen3-coder` |
+
 ## 3. Run the Setup Wizard for Claude Code / Cursor / Cline / VS Code (Copilot)
 ```bash
 cerebras-mcp --config

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can set this key in your MCP settings under OPENROUTER_API_KEY, and it will 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `CEREBRAS_API_KEY` | Your Cerebras API key (required) | - |
-| `CEREBRAS_MODEL` | Cerebras model to use | `zai-glm-4.6` |
+| `CEREBRAS_MODEL` | Cerebras model to use | `zai-glm-4.7` |
 | `OPENROUTER_API_KEY` | OpenRouter API key (optional fallback) | - |
 | `OPENROUTER_MODEL` | OpenRouter model to use | `qwen/qwen3-coder` |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,9 +15,10 @@ This document covers the testing tools, processes, and conventions for the cereb
 ### Testing
 
 ```bash
-npm test              # Run all tests once
-npm run test:watch    # Run tests in watch mode (re-runs on file changes)
-npm run test:coverage # Run tests with coverage report
+npm test                # Run unit tests once
+npm run test:watch      # Run unit tests in watch mode (re-runs on file changes)
+npm run test:coverage   # Run unit tests with coverage report
+npm run test:integration # Run integration tests (requires API keys)
 ```
 
 ### Linting
@@ -57,6 +58,10 @@ tests/
 │   ├── planner.test.js
 │   ├── tool-handlers.test.js
 │   └── worker.test.js
+├── integration/
+│   ├── helpers/
+│   │   └── setup.js
+│   └── write.integration.test.js
 └── utils/
     ├── code-cleaner.test.js
     └── file-utils.test.js
@@ -66,8 +71,8 @@ tests/
 
 ### File Naming
 
-- Test files must end with `.test.js`
-- Place tests in the matching directory under `tests/`
+- Unit test files: `*.test.js` under `tests/` mirroring `src/` structure
+- Integration test files: `*.integration.test.js` under `tests/integration/`
 - Example: `src/api/cerebras.js` → `tests/api/cerebras.test.js`
 
 ### Test Structure
@@ -132,9 +137,40 @@ it('should reject with error', async () => {
 });
 ```
 
+## Integration Tests
+
+Integration tests make real API calls and require provider API keys to be set as environment variables.
+
+### Prerequisites
+
+- `CEREBRAS_API_KEY` — required for Cerebras provider tests
+- `OPENROUTER_API_KEY` — required for OpenRouter provider tests
+- Both keys required for fallback tests (Cerebras → OpenRouter)
+
+Tests for a provider are automatically skipped if its API key is not set.
+
+### What's Tested
+
+| Test | Description |
+|------|-------------|
+| provider: cerebras | Direct Cerebras API call |
+| provider: openrouter | Direct OpenRouter API call |
+| fallback: cerebras → openrouter | Cerebras fails (invalid key), router falls back to OpenRouter |
+
+### Helpers (`tests/integration/helpers/setup.js`)
+
+- `forceProvider(provider)` — isolates a single provider by blanking the other's key
+- `forceFallback()` — sets an invalid Cerebras key (truthy but fails auth) to trigger the fallback path
+- `hasProvider(provider)` — checks if a provider's API key is available
+- `createTempDir()` — creates a temp directory for test file output, returns `{ dir, cleanup }`
+
+### Configuration
+
+Integration tests use a separate vitest config (`vitest.integration.config.js`) with a 30-second test timeout to accommodate real API latency.
+
 ## Configuration Files
 
-### vitest.config.js
+### vitest.config.js (unit tests)
 
 ```javascript
 import { defineConfig } from 'vitest/config';
@@ -150,6 +186,21 @@ export default defineConfig({
       include: ['src/**/*.js'],
       exclude: ['src/index.js'],
     },
+  },
+});
+```
+
+### vitest.integration.config.js (integration tests)
+
+```javascript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/integration/**/*.test.js'],
+    testTimeout: 30000,
   },
 });
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,211 @@
+# Testing Guide
+
+This document covers the testing tools, processes, and conventions for the cerebras-code-mcp project.
+
+## Tools
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| [Vitest](https://vitest.dev/) | 4.x | Unit testing framework |
+| [ESLint](https://eslint.org/) | 9.x | Code linting |
+| [Prettier](https://prettier.io/) | 3.x | Code formatting |
+
+## npm Scripts
+
+### Testing
+
+```bash
+npm test              # Run all tests once
+npm run test:watch    # Run tests in watch mode (re-runs on file changes)
+npm run test:coverage # Run tests with coverage report
+```
+
+### Linting
+
+```bash
+npm run lint          # Check for lint errors
+npm run lint:fix      # Auto-fix lint errors where possible
+```
+
+### Formatting
+
+```bash
+npm run format        # Format all files with Prettier
+npm run format:check  # Check if files are formatted (CI-friendly)
+```
+
+## Directory Structure
+
+Tests mirror the `src/` directory structure:
+
+```
+tests/
+├── api/
+│   ├── router/
+│   │   └── router.test.js
+│   ├── cerebras.test.js
+│   ├── openrouter.test.js
+│   └── rate-limiter.test.js
+├── config/
+│   └── constants.test.js
+├── formatting/
+│   ├── response-formatter.test.js
+│   └── syntax-highlighter.test.js
+├── server/
+│   ├── agent-spawner.test.js
+│   ├── mcp-server.test.js
+│   ├── planner.test.js
+│   ├── tool-handlers.test.js
+│   └── worker.test.js
+└── utils/
+    ├── code-cleaner.test.js
+    └── file-utils.test.js
+```
+
+## Writing Tests
+
+### File Naming
+
+- Test files must end with `.test.js`
+- Place tests in the matching directory under `tests/`
+- Example: `src/api/cerebras.js` → `tests/api/cerebras.test.js`
+
+### Test Structure
+
+```javascript
+import { describe, it, expect, vi } from 'vitest';
+import { myFunction } from '../../src/path/to/module.js';
+
+describe('myFunction', () => {
+  it('should do something specific', () => {
+    const result = myFunction(input);
+    expect(result).toBe(expectedOutput);
+  });
+
+  it('should handle edge case', () => {
+    expect(() => myFunction(badInput)).toThrow();
+  });
+});
+```
+
+### Common Assertions
+
+```javascript
+expect(value).toBe(expected)           // Strict equality
+expect(value).toEqual(expected)        // Deep equality
+expect(value).toBeTruthy()             // Truthy check
+expect(value).toBeNull()               // Null check
+expect(value).toBeUndefined()          // Undefined check
+expect(value).toContain(item)          // Array/string contains
+expect(fn).toThrow()                   // Throws error
+expect(fn).toThrow('message')          // Throws specific error
+```
+
+### Mocking
+
+```javascript
+import { vi } from 'vitest';
+
+// Mock a function
+const mockFn = vi.fn();
+mockFn.mockReturnValue('mocked');
+
+// Mock a module
+vi.mock('../../src/api/cerebras.js', () => ({
+  callCerebras: vi.fn().mockResolvedValue('mocked response'),
+}));
+
+// Spy on existing function
+const spy = vi.spyOn(object, 'method');
+```
+
+### Async Tests
+
+```javascript
+it('should handle async operations', async () => {
+  const result = await asyncFunction();
+  expect(result).toBe(expected);
+});
+
+it('should reject with error', async () => {
+  await expect(asyncFunction()).rejects.toThrow('error message');
+});
+```
+
+## Configuration Files
+
+### vitest.config.js
+
+```javascript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.js'],
+      exclude: ['src/index.js'],
+    },
+  },
+});
+```
+
+### eslint.config.js
+
+Uses ESLint 9 flat config format with:
+- Recommended JS rules
+- Prettier compatibility (disables conflicting rules)
+- Node.js globals
+- Custom rules for unused vars and const preference
+
+### .prettierrc
+
+```json
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2
+}
+```
+
+## CI Integration
+
+For CI pipelines, use these commands:
+
+```bash
+# Check formatting (fails if not formatted)
+npm run format:check
+
+# Run linter (fails on errors)
+npm run lint
+
+# Run tests (fails on test failures)
+npm test
+
+# Run tests with coverage (optional)
+npm run test:coverage
+```
+
+## Coverage
+
+Run coverage report:
+
+```bash
+npm run test:coverage
+```
+
+This generates:
+- Terminal output with coverage summary
+- HTML report in `coverage/` directory
+
+Coverage targets:
+- Statements: 80%+
+- Branches: 80%+
+- Functions: 80%+
+- Lines: 80%+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,34 @@
+import js from "@eslint/js";
+import globals from "globals";
+import eslintConfigPrettier from "eslint-config-prettier";
+
+export default [
+  js.configs.recommended,
+  eslintConfigPrettier,
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+        ...globals.es2022,
+      },
+    },
+    rules: {
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "no-console": "off",
+      "prefer-const": "error",
+      "no-var": "error",
+    },
+  },
+  {
+    ignores: [
+      "node_modules/",
+      ".ai/",
+      ".claude/",
+      "coverage/",
+      "dist/",
+      ".pytest_cache/",
+    ],
+  },
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,7 @@ export default [
       },
     },
     rules: {
-      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" }],
       "no-console": "off",
       "prefer-const": "error",
       "no-var": "error",
@@ -29,6 +29,7 @@ export default [
       "coverage/",
       "dist/",
       ".pytest_cache/",
+      "src/config/interactive-config.js",
     ],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,35 +9,1547 @@
       "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^0.5.0",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "diff": "^8.0.2",
         "zod": "^4.0.17"
       },
       "bin": {
         "cerebras-mcp": "src/index.js"
       },
+      "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@vitest/coverage-v8": "^4.0.18",
+        "eslint": "^9.39.2",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.3.0",
+        "prettier": "3.8.1",
+        "vitest": "^4.0.18"
+      },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==",
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/bytes": {
@@ -49,6 +1561,112 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -57,6 +1675,79 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -68,40 +1759,786 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
-      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
-    "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
       },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
+      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inherits": {
@@ -110,40 +2547,733 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "license": "ISC",
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": ">= 12"
       }
     },
-    "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
       },
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/read": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/read/-/read-4.1.0.tgz",
-      "integrity": "sha512-uRfX6K+f+R8OOrYScaM3ixPY4erg69f8DN6pgTvMcA9iRc8iDhwrA4m3Yu8YYKsXJgVvum+m8PkRboZwwuLzYA==",
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "^2.0.0"
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/safer-buffer": {
@@ -152,19 +3282,271 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -176,6 +3558,33 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -185,6 +3594,239 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zod": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.0.tgz",
@@ -192,6 +3834,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.js",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,14 @@
     "cerebras-mcp": "src/index.js"
   },
   "scripts": {
-    "test": "node test-mcp-server.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "start": "node src/index.js",
-    "run": "node src/index.js",
     "dev": "node src/index.js"
   },
   "keywords": [
@@ -40,8 +45,17 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "diff": "^8.0.2",
     "zod": "^4.0.17"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.2",
+    "@vitest/coverage-v8": "^4.0.18",
+    "eslint": "^9.39.2",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.3.0",
+    "prettier": "3.8.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/api/cerebras.js
+++ b/src/api/cerebras.js
@@ -5,8 +5,7 @@ import { readFileContent, getLanguageFromFile } from '../utils/file-utils.js';
 import { cleanCodeResponse } from '../utils/code-cleaner.js';
 // Call Cerebras Code API - generates only code, no explanations
 export async function callCerebras(prompt, context = "", outputFile = "", language = null, contextFiles = []) {
-  try {
-    // Check if Cerebras API key is available
+  // Check if Cerebras API key is available
     if (!config.cerebrasApiKey) {
       throw new Error("No Cerebras API key found. Please set CEREBRAS_API_KEY environment variable.");
     }
@@ -130,8 +129,4 @@ export async function callCerebras(prompt, context = "", outputFile = "", langua
       // Re-throw the error for the router to handle fallback logic
       throw new Error(`Cerebras API call failed: ${error.message}`);
     }
-  } catch (error) {
-    // Re-throw any setup errors for the router to handle fallback logic
-    throw error;
-  }
 }

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -48,12 +48,8 @@ export const getClineRulesPath = () => {
     // Windows: Documents\Cline\Rules
     return path.join(homeDir, 'Documents', 'Cline', 'Rules');
   } else {
-    // macOS/Linux: ~/Documents/Cline/Rules (fallback to ~/Cline/Rules)
-    const documentsPath = path.join(homeDir, 'Documents', 'Cline', 'Rules');
-    const fallbackPath = path.join(homeDir, 'Cline', 'Rules');
-    
-    // For now, return the primary path - the wizard will handle directory creation
-    return documentsPath;
+    // macOS/Linux: ~/Documents/Cline/Rules
+    return path.join(homeDir, 'Documents', 'Cline', 'Rules');
   }
 };
 
@@ -67,7 +63,7 @@ export async function debugLog(message) {
   // Also append to file
   try {
     await fs.appendFile(LOG_FILE, logMessage);
-  } catch (error) {
+  } catch (_error) {
     // Ignore file write errors
   }
 }

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -10,7 +10,7 @@ export const config = {
   openRouterApiKey: process.env.OPENROUTER_API_KEY,
   openRouterSiteUrl: process.env.OPENROUTER_SITE_URL || 'https://github.com/cerebras/cerebras-code-mcp',
   openRouterSiteName: process.env.OPENROUTER_SITE_NAME || 'Cerebras MCP',
-  openRouterModel: 'qwen/qwen3-coder'
+  openRouterModel: process.env.OPENROUTER_MODEL || 'qwen/qwen3-coder'
 };
 
 // Debug logging to file  

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -2,7 +2,7 @@
 export const config = {
   // Cerebras configuration
   cerebrasApiKey: process.env.CEREBRAS_API_KEY,
-  cerebrasModel: process.env.CEREBRAS_MODEL || "zai-glm-4.6",
+  cerebrasModel: process.env.CEREBRAS_MODEL || "zai-glm-4.7",
   maxTokens: process.env.CEREBRAS_MAX_TOKENS ? parseInt(process.env.CEREBRAS_MAX_TOKENS) : null,
   temperature: parseFloat(process.env.CEREBRAS_TEMPERATURE) || 0.1,
   

--- a/src/formatting/diff-formatter.js
+++ b/src/formatting/diff-formatter.js
@@ -1,5 +1,4 @@
 import { createPatch } from 'diff';
-import path from 'path';
 
 // Generate a simple diff between old and new content
 export function generateDiff(oldContent, newContent) {
@@ -8,7 +7,7 @@ export function generateDiff(oldContent, newContent) {
   const oldLines = oldContent.split('\n');
   const newLines = newContent.split('\n');
   
-  let diff = [];
+  const diff = [];
   let i = 0, j = 0;
   
   while (i < oldLines.length || j < newLines.length) {

--- a/src/formatting/response-formatter.js
+++ b/src/formatting/response-formatter.js
@@ -1,5 +1,4 @@
 import { createPatch } from 'diff';
-import path from 'path';
 import { syntaxHighlight } from './syntax-highlighter.js';
 import { getLanguageFromFile } from '../utils/file-utils.js';
 

--- a/src/server/tool-handlers.js
+++ b/src/server/tool-handlers.js
@@ -51,7 +51,7 @@ export async function handleWriteTool(args) {
     await writeFileContent(file_path, cleanResult);
 
     // Format the response based on operation type
-    let responseContent = [];
+    const responseContent = [];
     const fileName = path.basename(file_path);
 
     if (isEdit && existingContent) {

--- a/tests/api/cerebras.test.js
+++ b/tests/api/cerebras.test.js
@@ -268,4 +268,91 @@ describe('callCerebras', () => {
     const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
     expect(requestData.messages[0].content).toContain('typescript');
   });
+
+  it('should log warning and continue when context file read fails', async () => {
+    vi.mocked(readFileContent).mockImplementation((filePath) => {
+      if (filePath === '/bad/context.js') return Promise.reject(new Error('ENOENT: no such file'));
+      return Promise.resolve(null);
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const promise = callCerebras('test', '', 'output.js', null, ['/bad/context.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Warning: Could not read context file'));
+    consoleSpy.mockRestore();
+  });
+
+  it('should skip context files section when all context files match output file', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('test', '', '/abs/output.js', null, ['/abs/output.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).not.toContain('Context Files:');
+  });
+
+  it('should skip context file with empty content', async () => {
+    vi.mocked(readFileContent).mockImplementation((filePath) => {
+      if (filePath === '/empty/context.js') return Promise.resolve('');
+      return Promise.resolve(null);
+    });
+    const promise = callCerebras('test', '', 'output.js', null, ['/empty/context.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).not.toContain('/empty/context.js');
+  });
+
+  it('should show Unknown error when API error has no message', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(500);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({}));
+    res.emit('end');
+
+    await expect(promise).rejects.toThrow('Unknown error');
+  });
 });

--- a/tests/api/cerebras.test.js
+++ b/tests/api/cerebras.test.js
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import https from 'https';
+import { EventEmitter } from 'events';
+
+vi.mock('https');
+
+// Use vi.hoisted to create a mutable config that the mock factory can access
+const mockConfig = vi.hoisted(() => ({
+  cerebrasApiKey: 'test-key',
+  cerebrasModel: 'test-model',
+  temperature: 0.7,
+  maxTokens: undefined,
+  topP: undefined,
+  clearThinking: false
+}));
+
+vi.mock('../../src/config/constants.js', () => ({
+  config: mockConfig
+}));
+
+vi.mock('../../src/utils/file-utils.js', () => ({
+  readFileContent: vi.fn(),
+  getLanguageFromFile: vi.fn(() => 'javascript'),
+  expandContextPaths: vi.fn(paths => Promise.resolve(paths || []))
+}));
+
+vi.mock('../../src/utils/code-cleaner.js', () => ({
+  cleanCodeResponse: vi.fn(code => code)
+}));
+
+// Import after mocks are set up
+import { callCerebras } from '../../src/api/cerebras.js';
+import { readFileContent, getLanguageFromFile } from '../../src/utils/file-utils.js';
+import { cleanCodeResponse } from '../../src/utils/code-cleaner.js';
+
+function createMockRequest() {
+  const req = new EventEmitter();
+  req.write = vi.fn();
+  req.end = vi.fn();
+  req.destroy = vi.fn();
+  req.setTimeout = vi.fn((timeout, callback) => {
+    req._timeoutCallback = callback;
+  });
+  return req;
+}
+
+function createMockResponse(statusCode, headers = {}) {
+  const res = new EventEmitter();
+  res.statusCode = statusCode;
+  res.headers = headers;
+  return res;
+}
+
+describe('callCerebras', () => {
+  let mockReq;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset config to defaults
+    mockConfig.cerebrasApiKey = 'test-key';
+    mockConfig.cerebrasModel = 'test-model';
+    mockConfig.temperature = 0.7;
+    mockConfig.maxTokens = undefined;
+    mockConfig.topP = undefined;
+    mockConfig.clearThinking = false;
+
+    mockReq = createMockRequest();
+    vi.mocked(https.request).mockImplementation((options, callback) => {
+      mockReq._callback = callback;
+      return mockReq;
+    });
+  });
+
+  it('should return cleaned code on successful response', async () => {
+    vi.mocked(cleanCodeResponse).mockReturnValue('cleaned code');
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('Create a function', 'context', 'output.js');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'raw code' } }]
+    }));
+    res.emit('end');
+
+    const result = await promise;
+    expect(result).toBe('cleaned code');
+    expect(cleanCodeResponse).toHaveBeenCalledWith('raw code');
+  });
+
+  it('should throw error when API key is missing', async () => {
+    mockConfig.cerebrasApiKey = '';
+
+    await expect(callCerebras('test')).rejects.toThrow('No Cerebras API key found');
+  });
+
+  it('should throw error on non-200 status code', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(500);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({ error: { message: 'Server error' } }));
+    res.emit('end');
+
+    await expect(promise).rejects.toThrow('Cerebras API error: 500');
+  });
+
+  it('should throw error on network failure', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    mockReq.emit('error', new Error('Network failed'));
+
+    await expect(promise).rejects.toThrow('Request failed: Network failed');
+  });
+
+  it('should throw error on timeout', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._timeoutCallback).toBeDefined();
+    });
+
+    mockReq._timeoutCallback();
+
+    await expect(promise).rejects.toThrow('Request timeout after 30 seconds');
+    expect(mockReq.destroy).toHaveBeenCalled();
+  });
+
+  it('should throw error on invalid JSON response', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', 'not valid json');
+    res.emit('end');
+
+    await expect(promise).rejects.toThrow('Failed to parse API response');
+  });
+
+  it('should include context in prompt', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('Create function', 'This is context', 'output.js');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).toContain('Context: This is context');
+  });
+
+  it('should read and include context files', async () => {
+    vi.mocked(readFileContent).mockResolvedValue('context file content');
+    const promise = callCerebras('Create function', '', 'output.js', null, ['/path/to/context.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    expect(readFileContent).toHaveBeenCalledWith('/path/to/context.js');
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).toContain('Context Files:');
+    expect(requestData.messages[1].content).toContain('context file content');
+  });
+
+  it('should filter output file from context files', async () => {
+    vi.mocked(readFileContent).mockResolvedValue('other content');
+    const promise = callCerebras('test', '', '/abs/path/output.js', null, ['/abs/path/output.js', '/other/file.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    expect(readFileContent).toHaveBeenCalledWith('/other/file.js');
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).not.toContain('/abs/path/output.js');
+  });
+
+  it('should include max_tokens when configured', async () => {
+    mockConfig.maxTokens = 1000;
+    vi.mocked(readFileContent).mockResolvedValue(null);
+
+    const promise = callCerebras('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.max_tokens).toBe(1000);
+  });
+
+  it('should use detected language for output file', async () => {
+    vi.mocked(getLanguageFromFile).mockReturnValue('typescript');
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callCerebras('test', '', 'output.ts');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    expect(getLanguageFromFile).toHaveBeenCalledWith('output.ts', null);
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[0].content).toContain('typescript');
+  });
+});

--- a/tests/api/openrouter.test.js
+++ b/tests/api/openrouter.test.js
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import https from 'https';
+import { EventEmitter } from 'events';
+
+vi.mock('https');
+
+const mockConfig = vi.hoisted(() => ({
+  openRouterApiKey: 'test-key',
+  openRouterModel: 'test-model',
+  openRouterSiteUrl: 'http://test.com',
+  openRouterSiteName: 'Test Site',
+  temperature: 0.7,
+  maxTokens: undefined,
+  topP: undefined
+}));
+
+vi.mock('../../src/config/constants.js', () => ({
+  config: mockConfig
+}));
+
+vi.mock('../../src/utils/file-utils.js', () => ({
+  readFileContent: vi.fn(),
+  getLanguageFromFile: vi.fn(() => 'javascript'),
+  expandContextPaths: vi.fn(paths => Promise.resolve(paths || []))
+}));
+
+vi.mock('../../src/utils/code-cleaner.js', () => ({
+  cleanCodeResponse: vi.fn(code => code)
+}));
+
+import { callOpenRouter } from '../../src/api/openrouter.js';
+import { readFileContent, getLanguageFromFile } from '../../src/utils/file-utils.js';
+import { cleanCodeResponse } from '../../src/utils/code-cleaner.js';
+
+function createMockRequest() {
+  const req = new EventEmitter();
+  req.write = vi.fn();
+  req.end = vi.fn();
+  req.destroy = vi.fn();
+  req.setTimeout = vi.fn((timeout, callback) => {
+    req._timeoutCallback = callback;
+  });
+  return req;
+}
+
+function createMockResponse(statusCode, headers = {}) {
+  const res = new EventEmitter();
+  res.statusCode = statusCode;
+  res.headers = headers;
+  return res;
+}
+
+describe('callOpenRouter', () => {
+  let mockReq;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig.openRouterApiKey = 'test-key';
+    mockConfig.openRouterModel = 'test-model';
+    mockConfig.openRouterSiteUrl = 'http://test.com';
+    mockConfig.openRouterSiteName = 'Test Site';
+    mockConfig.temperature = 0.7;
+    mockConfig.maxTokens = undefined;
+    mockConfig.topP = undefined;
+
+    mockReq = createMockRequest();
+    vi.mocked(https.request).mockImplementation((options, callback) => {
+      mockReq._callback = callback;
+      return mockReq;
+    });
+  });
+
+  it('should return cleaned code on successful response', async () => {
+    vi.mocked(cleanCodeResponse).mockReturnValue('cleaned code');
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callOpenRouter('Create a function', 'context', 'output.js');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'raw code' } }]
+    }));
+    res.emit('end');
+
+    const result = await promise;
+    expect(result).toBe('cleaned code');
+    expect(cleanCodeResponse).toHaveBeenCalledWith('raw code');
+  });
+
+  it('should throw error when API key is missing', async () => {
+    mockConfig.openRouterApiKey = '';
+
+    await expect(callOpenRouter('test')).rejects.toThrow('No OpenRouter API key available');
+  });
+
+  it('should throw error on non-200 status code', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callOpenRouter('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(500);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({ error: { message: 'Server error' } }));
+    res.emit('end');
+
+    await expect(promise).rejects.toThrow('OpenRouter API error: 500');
+  });
+
+  it('should throw error on network failure', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callOpenRouter('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    mockReq.emit('error', new Error('Network failed'));
+
+    await expect(promise).rejects.toThrow('Request failed: Network failed');
+  });
+
+  // Note: OpenRouter implementation doesn't have setTimeout, so no timeout test
+
+  it('should throw error on invalid JSON response', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callOpenRouter('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', 'not valid json');
+    res.emit('end');
+
+    await expect(promise).rejects.toThrow('Failed to parse API response');
+  });
+
+  it('should include context in prompt', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callOpenRouter('Create function', 'This is context', 'output.js');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).toContain('Context: This is context');
+  });
+
+  it('should read and include context files', async () => {
+    vi.mocked(readFileContent).mockResolvedValue('context file content');
+    const promise = callOpenRouter('Create function', '', 'output.js', null, ['/path/to/context.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    expect(readFileContent).toHaveBeenCalledWith('/path/to/context.js');
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).toContain('Context Files:');
+    expect(requestData.messages[1].content).toContain('context file content');
+  });
+
+  it('should filter output file from context files', async () => {
+    vi.mocked(readFileContent).mockResolvedValue('other content');
+    const promise = callOpenRouter('test', '', '/abs/path/output.js', null, ['/abs/path/output.js', '/other/file.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    expect(readFileContent).toHaveBeenCalledWith('/other/file.js');
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).not.toContain('/abs/path/output.js');
+  });
+
+  it('should include max_tokens when configured', async () => {
+    mockConfig.maxTokens = 1000;
+    vi.mocked(readFileContent).mockResolvedValue(null);
+
+    const promise = callOpenRouter('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.max_tokens).toBe(1000);
+  });
+
+  it('should use detected language for output file', async () => {
+    vi.mocked(getLanguageFromFile).mockReturnValue('typescript');
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callOpenRouter('test', '', 'output.ts');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    expect(getLanguageFromFile).toHaveBeenCalledWith('output.ts', null);
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[0].content).toContain('typescript');
+  });
+});

--- a/tests/api/openrouter.test.js
+++ b/tests/api/openrouter.test.js
@@ -255,4 +255,91 @@ describe('callOpenRouter', () => {
     const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
     expect(requestData.messages[0].content).toContain('typescript');
   });
+
+  it('should log warning and continue when context file read fails', async () => {
+    vi.mocked(readFileContent).mockImplementation((filePath) => {
+      if (filePath === '/bad/context.js') return Promise.reject(new Error('ENOENT: no such file'));
+      return Promise.resolve(null);
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const promise = callOpenRouter('test', '', 'output.js', null, ['/bad/context.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Warning: Could not read context file'));
+    consoleSpy.mockRestore();
+  });
+
+  it('should skip context files section when all context files match output file', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callOpenRouter('test', '', '/abs/output.js', null, ['/abs/output.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).not.toContain('Context Files:');
+  });
+
+  it('should skip context file with empty content', async () => {
+    vi.mocked(readFileContent).mockImplementation((filePath) => {
+      if (filePath === '/empty/context.js') return Promise.resolve('');
+      return Promise.resolve(null);
+    });
+    const promise = callOpenRouter('test', '', 'output.js', null, ['/empty/context.js']);
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(200);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({
+      choices: [{ message: { content: 'code' } }]
+    }));
+    res.emit('end');
+
+    await promise;
+
+    const requestData = JSON.parse(mockReq.write.mock.calls[0][0]);
+    expect(requestData.messages[1].content).not.toContain('/empty/context.js');
+  });
+
+  it('should show Unknown error when API error has no message', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    const promise = callOpenRouter('test');
+
+    await vi.waitFor(() => {
+      expect(mockReq._callback).toBeDefined();
+    });
+
+    const res = createMockResponse(500);
+    mockReq._callback(res);
+    res.emit('data', JSON.stringify({}));
+    res.emit('end');
+
+    await expect(promise).rejects.toThrow('Unknown error');
+  });
 });

--- a/tests/api/router/router.test.js
+++ b/tests/api/router/router.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockConfig = vi.hoisted(() => ({
+  cerebrasApiKey: 'test-cerebras-key',
+  openRouterApiKey: 'test-openrouter-key',
+  cerebrasModel: 'test-model',
+  openRouterModel: 'test-or-model'
+}));
+
+vi.mock('../../../src/config/constants.js', () => ({
+  config: mockConfig
+}));
+
+const mockCallCerebras = vi.hoisted(() => vi.fn());
+const mockCallOpenRouter = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/api/cerebras.js', () => ({
+  callCerebras: mockCallCerebras
+}));
+
+vi.mock('../../../src/api/openrouter.js', () => ({
+  callOpenRouter: mockCallOpenRouter
+}));
+
+import { routeAPICall, getAvailableProviders } from '../../../src/api/router/router.js';
+
+describe('routeAPICall', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig.cerebrasApiKey = 'test-cerebras-key';
+    mockConfig.openRouterApiKey = 'test-openrouter-key';
+  });
+
+  it('should route to Cerebras when Cerebras API key is available', async () => {
+    mockCallCerebras.mockResolvedValue('cerebras result');
+
+    const result = await routeAPICall('test prompt', 'context', 'output.js');
+
+    expect(mockCallCerebras).toHaveBeenCalledWith('test prompt', 'context', 'output.js', null, []);
+    expect(result).toBe('cerebras result');
+  });
+
+  it('should route to OpenRouter when only OpenRouter API key is available', async () => {
+    mockConfig.cerebrasApiKey = '';
+    mockCallOpenRouter.mockResolvedValue('openrouter result');
+
+    const result = await routeAPICall('test prompt');
+
+    expect(mockCallOpenRouter).toHaveBeenCalled();
+    expect(result).toBe('openrouter result');
+  });
+
+  it('should throw error when no API keys are configured', async () => {
+    mockConfig.cerebrasApiKey = '';
+    mockConfig.openRouterApiKey = '';
+
+    await expect(routeAPICall('test')).rejects.toThrow('No API keys configured');
+  });
+
+  it('should fallback to OpenRouter when Cerebras fails', async () => {
+    mockCallCerebras.mockRejectedValue(new Error('Cerebras failed'));
+    mockCallOpenRouter.mockResolvedValue('fallback result');
+
+    const result = await routeAPICall('test prompt');
+
+    expect(mockCallCerebras).toHaveBeenCalled();
+    expect(mockCallOpenRouter).toHaveBeenCalled();
+    expect(result).toBe('fallback result');
+  });
+
+  it('should throw when both providers fail', async () => {
+    mockCallCerebras.mockRejectedValue(new Error('Cerebras failed'));
+    mockCallOpenRouter.mockRejectedValue(new Error('OpenRouter failed'));
+
+    await expect(routeAPICall('test')).rejects.toThrow('Both primary');
+  });
+
+  it('should pass all arguments to provider', async () => {
+    mockCallCerebras.mockResolvedValue('result');
+
+    await routeAPICall('prompt', 'context', 'file.js', 'typescript', ['/ctx.js']);
+
+    expect(mockCallCerebras).toHaveBeenCalledWith(
+      'prompt', 'context', 'file.js', 'typescript', ['/ctx.js']
+    );
+  });
+});
+
+describe('getAvailableProviders', () => {
+  beforeEach(() => {
+    mockConfig.cerebrasApiKey = 'test-cerebras-key';
+    mockConfig.openRouterApiKey = 'test-openrouter-key';
+  });
+
+  it('should return both providers when both keys available', () => {
+    const providers = getAvailableProviders();
+
+    expect(providers).toHaveLength(2);
+    expect(providers[0].name).toBe('cerebras');
+    expect(providers[1].name).toBe('openrouter');
+  });
+
+  it('should return only Cerebras when only Cerebras key available', () => {
+    mockConfig.openRouterApiKey = '';
+
+    const providers = getAvailableProviders();
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0].name).toBe('cerebras');
+  });
+
+  it('should return empty array when no keys available', () => {
+    mockConfig.cerebrasApiKey = '';
+    mockConfig.openRouterApiKey = '';
+
+    const providers = getAvailableProviders();
+
+    expect(providers).toHaveLength(0);
+  });
+});

--- a/tests/api/router/router.test.js
+++ b/tests/api/router/router.test.js
@@ -84,6 +84,21 @@ describe('routeAPICall', () => {
       'prompt', 'context', 'file.js', 'typescript', ['/ctx.js']
     );
   });
+
+  it('should re-throw when OpenRouter is primary and no fallback is available', async () => {
+    mockConfig.cerebrasApiKey = '';
+    mockCallOpenRouter.mockRejectedValue(new Error('OpenRouter failed'));
+
+    await expect(routeAPICall('test')).rejects.toThrow('OpenRouter failed');
+  });
+
+  it('should not attempt fallback when OpenRouter is the only provider', async () => {
+    mockConfig.cerebrasApiKey = '';
+    mockCallOpenRouter.mockRejectedValue(new Error('OpenRouter failed'));
+
+    await expect(routeAPICall('test')).rejects.toThrow();
+    expect(mockCallCerebras).not.toHaveBeenCalled();
+  });
 });
 
 describe('getAvailableProviders', () => {

--- a/tests/config/constants.test.js
+++ b/tests/config/constants.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import fs from 'fs/promises';
 
 vi.mock('fs/promises', () => ({

--- a/tests/config/constants.test.js
+++ b/tests/config/constants.test.js
@@ -63,3 +63,76 @@ describe('debugLog', () => {
     consoleSpy.mockRestore();
   });
 });
+
+describe('getClineRulesPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    vi.resetModules();
+  });
+
+  it('should return a path containing Documents/Cline/Rules on linux', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    vi.resetModules();
+
+    const { getClineRulesPath } = await import('../../src/config/constants.js');
+    const result = getClineRulesPath();
+
+    expect(result).toContain('Documents');
+    expect(result).toContain('Cline');
+    expect(result).toContain('Rules');
+  });
+
+  it('should return a path containing Documents/Cline/Rules on win32', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    vi.resetModules();
+
+    const { getClineRulesPath } = await import('../../src/config/constants.js');
+    const result = getClineRulesPath();
+
+    expect(result).toContain('Documents');
+    expect(result).toContain('Cline');
+    expect(result).toContain('Rules');
+  });
+});
+
+describe('config env var branches', () => {
+  const savedModel = process.env.CEREBRAS_MODEL;
+  const savedMaxTokens = process.env.CEREBRAS_MAX_TOKENS;
+  const savedORModel = process.env.OPENROUTER_MODEL;
+
+  afterEach(() => {
+    if (savedModel === undefined) delete process.env.CEREBRAS_MODEL;
+    else process.env.CEREBRAS_MODEL = savedModel;
+    if (savedMaxTokens === undefined) delete process.env.CEREBRAS_MAX_TOKENS;
+    else process.env.CEREBRAS_MAX_TOKENS = savedMaxTokens;
+    if (savedORModel === undefined) delete process.env.OPENROUTER_MODEL;
+    else process.env.OPENROUTER_MODEL = savedORModel;
+    vi.resetModules();
+  });
+
+  it('should use CEREBRAS_MODEL when set', async () => {
+    process.env.CEREBRAS_MODEL = 'custom-model';
+    vi.resetModules();
+
+    const { config } = await import('../../src/config/constants.js');
+    expect(config.cerebrasModel).toBe('custom-model');
+  });
+
+  it('should parse CEREBRAS_MAX_TOKENS when set', async () => {
+    process.env.CEREBRAS_MAX_TOKENS = '2048';
+    vi.resetModules();
+
+    const { config } = await import('../../src/config/constants.js');
+    expect(config.maxTokens).toBe(2048);
+  });
+
+  it('should use OPENROUTER_MODEL when set', async () => {
+    process.env.OPENROUTER_MODEL = 'custom-or-model';
+    vi.resetModules();
+
+    const { config } = await import('../../src/config/constants.js');
+    expect(config.openRouterModel).toBe('custom-or-model');
+  });
+});

--- a/tests/config/constants.test.js
+++ b/tests/config/constants.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+
+vi.mock('fs/promises', () => ({
+  default: {
+    appendFile: vi.fn()
+  }
+}));
+
+describe('debugLog', () => {
+  const originalEnv = process.env.CEREBRAS_DEBUG;
+
+  afterEach(() => {
+    process.env.CEREBRAS_DEBUG = originalEnv;
+    vi.resetModules();
+  });
+
+  it('should always log to console.error', async () => {
+    // Note: v1.3.3 debugLog always logs regardless of CEREBRAS_DEBUG
+    vi.resetModules();
+
+    const { debugLog } = await import('../../src/config/constants.js');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await debugLog('test message');
+
+    expect(consoleSpy).toHaveBeenCalledWith('test message');
+    consoleSpy.mockRestore();
+  });
+
+  it('should log to console and file when CEREBRAS_DEBUG is true', async () => {
+    process.env.CEREBRAS_DEBUG = 'true';
+    vi.resetModules();
+
+    const { debugLog } = await import('../../src/config/constants.js');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(fs.appendFile).mockResolvedValue(undefined);
+
+    await debugLog('test message');
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('test message'));
+    expect(fs.appendFile).toHaveBeenCalledWith(
+      expect.stringContaining('cerebras-mcp-debug.log'),
+      expect.stringContaining('test message')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should handle file write errors gracefully', async () => {
+    process.env.CEREBRAS_DEBUG = 'true';
+    vi.resetModules();
+
+    const { debugLog } = await import('../../src/config/constants.js');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(fs.appendFile).mockRejectedValue(new Error('Write failed'));
+
+    // Should not throw
+    await expect(debugLog('test message')).resolves.not.toThrow();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/formatting/diff-formatter.test.js
+++ b/tests/formatting/diff-formatter.test.js
@@ -41,6 +41,13 @@ describe('generateDiff', () => {
     expect(result).toContain('+ x');
     expect(result).toContain('- b');
   });
+
+  it('should show removed lines when new content is shorter', () => {
+    const result = generateDiff('a\nb\nc', 'a');
+    expect(result).toContain('- b');
+    expect(result).toContain('- c');
+    expect(result).not.toContain('+');
+  });
 });
 
 describe('generateGitDiff', () => {

--- a/tests/formatting/diff-formatter.test.js
+++ b/tests/formatting/diff-formatter.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { generateDiff, generateGitDiff } from '../../src/formatting/diff-formatter.js';
+
+describe('generateDiff', () => {
+  it('should return null when oldContent is null', () => {
+    expect(generateDiff(null, 'new content')).toBeNull();
+  });
+
+  it('should return null when newContent is null', () => {
+    expect(generateDiff('old content', null)).toBeNull();
+  });
+
+  it('should return null when both are null', () => {
+    expect(generateDiff(null, null)).toBeNull();
+  });
+
+  it('should return null when content is identical', () => {
+    expect(generateDiff('line1\nline2', 'line1\nline2')).toBeNull();
+  });
+
+  it('should show added lines', () => {
+    const result = generateDiff('line1', 'line1\nline2');
+    expect(result).toContain('+ line2');
+  });
+
+  it('should show removed lines', () => {
+    const result = generateDiff('line1\nline2', 'line1');
+    expect(result).toContain('- line2');
+  });
+
+  it('should show both added and removed lines', () => {
+    const result = generateDiff('old line', 'new line');
+    expect(result).toContain('+ new line');
+    expect(result).toContain('- old line');
+  });
+
+  it('should handle multi-line changes', () => {
+    const old = 'a\nb\nc';
+    const newContent = 'a\nx\nc';
+    const result = generateDiff(old, newContent);
+    expect(result).toContain('+ x');
+    expect(result).toContain('- b');
+  });
+});
+
+describe('generateGitDiff', () => {
+  it('should return null when newContent is null', () => {
+    expect(generateGitDiff('old', null, 'file.js')).toBeNull();
+  });
+
+  it('should handle new file creation (no old content)', () => {
+    const result = generateGitDiff(null, 'line1\nline2', '/path/to/file.js');
+
+    expect(result).toContain('--- /dev/null');
+    expect(result).toContain('+++ b/file.js');
+    expect(result).toContain('@@ -0,0 +1,2 @@');
+    expect(result).toContain('+line1');
+    expect(result).toContain('+line2');
+  });
+
+  it('should handle empty old content as new file', () => {
+    const result = generateGitDiff('', 'new content', '/path/file.js');
+    expect(result).not.toBeNull();
+  });
+
+  it('should generate diff for modified files', () => {
+    const old = 'line1\nline2';
+    const newContent = 'line1\nline3';
+    const result = generateGitDiff(old, newContent, '/path/to/file.js');
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('file.js');
+  });
+
+  it('should extract filename from full path', () => {
+    const result = generateGitDiff(null, 'content', '/long/path/to/myfile.ts');
+    expect(result).toContain('myfile.ts');
+  });
+});

--- a/tests/formatting/response-formatter.test.js
+++ b/tests/formatting/response-formatter.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { formatEditResponse, formatCreateResponse } from '../../src/formatting/response-formatter.js';
 
 describe('formatEditResponse', () => {
@@ -43,6 +43,13 @@ describe('formatEditResponse', () => {
   it('should handle empty lines in removals', () => {
     const result = formatEditResponse('file.js', 'line1\n\nline3', 'line1\nline3', '/path/file.js');
     expect(result).not.toBeNull();
+  });
+
+  it('should handle typescript files by mapping to javascript highlighting', () => {
+    const result = formatEditResponse('file.ts', 'const old = 1;', 'const new_ = 2;', '/path/file.ts');
+
+    expect(result).not.toBeNull();
+    expect(result.text).toContain('file.ts');
   });
 
   it('should include ANSI color codes', () => {
@@ -102,8 +109,138 @@ describe('formatCreateResponse', () => {
     expect(result.text).toContain('3');
   });
 
+  it('should handle typescript files in create response', () => {
+    const result = formatCreateResponse('file.ts', 'const x: number = 1;', '/path/file.ts');
+
+    expect(result).not.toBeNull();
+    expect(result.text).toContain('file.ts');
+  });
+
   it('should include green color for additions', () => {
     const result = formatCreateResponse('file.js', 'content', '/path/file.js');
     expect(result.text).toContain('\x1b[32m');
+  });
+});
+
+describe('formatEditResponse with IDE variants', () => {
+  const originalIDE = process.env.CEREBRAS_MCP_IDE;
+
+  afterEach(() => {
+    if (originalIDE === undefined) {
+      delete process.env.CEREBRAS_MCP_IDE;
+    } else {
+      process.env.CEREBRAS_MCP_IDE = originalIDE;
+    }
+  });
+
+  it('should use emojis without ANSI colors for cursor IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'cursor';
+    const result = formatEditResponse('file.js', 'old', 'new', '/path/file.js');
+
+    expect(result).not.toBeNull();
+    expect(result.text).not.toContain('\x1b[');
+    expect(result.text).toContain('Updated');
+  });
+
+  it('should use no emojis and no ANSI colors for crush IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'crush';
+    const result = formatEditResponse('file.js', 'old', 'new', '/path/file.js');
+
+    expect(result).not.toBeNull();
+    expect(result.text).not.toContain('\x1b[');
+    expect(result.text).toContain('Updated');
+    expect(result.text).not.toContain('✅');
+  });
+
+  it('should truncate large diffs in edit response', () => {
+    const oldLines = Array(60).fill('old line').join('\n');
+    const newLines = Array(60).fill('new line').join('\n');
+    const result = formatEditResponse('file.js', oldLines, newLines, '/path/file.js');
+
+    expect(result).not.toBeNull();
+    expect(result.text).toContain('lines hidden');
+  });
+
+  it('should truncate large diffs without ANSI colors for crush IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'crush';
+    const oldLines = Array(40).fill('old line').join('\n');
+    const newLines = Array(40).fill('new line').join('\n');
+    const result = formatEditResponse('file.js', oldLines, newLines, '/path/file.js');
+
+    expect(result).not.toBeNull();
+    expect(result.text).toContain('lines hidden');
+    expect(result.text).not.toContain('\x1b[');
+  });
+
+  it('should show plural additions/removals without colors for crush IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'crush';
+    const result = formatEditResponse('file.js', 'a\nb\nc', 'x\ny\nz', '/path/file.js');
+
+    expect(result).not.toBeNull();
+    expect(result.text).toContain('additions');
+    expect(result.text).toContain('removals');
+    expect(result.text).not.toContain('\x1b[');
+  });
+});
+
+describe('formatCreateResponse with IDE variants', () => {
+  const originalIDE = process.env.CEREBRAS_MCP_IDE;
+
+  afterEach(() => {
+    if (originalIDE === undefined) {
+      delete process.env.CEREBRAS_MCP_IDE;
+    } else {
+      process.env.CEREBRAS_MCP_IDE = originalIDE;
+    }
+  });
+
+  it('should use emojis without ANSI colors for cursor IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'cursor';
+    const result = formatCreateResponse('new.js', 'const x = 1;', '/path/new.js');
+
+    expect(result.text).not.toContain('\x1b[');
+    expect(result.text).toContain('Created');
+  });
+
+  it('should use no emojis and no ANSI colors for crush IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'crush';
+    const result = formatCreateResponse('new.js', 'const x = 1;', '/path/new.js');
+
+    expect(result.text).not.toContain('\x1b[');
+    expect(result.text).toContain('Created');
+    expect(result.text).not.toContain('✨');
+  });
+
+  it('should use minimal diff style for cline IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'cline';
+    const result = formatCreateResponse('new.js', 'const x = 1;', '/path/new.js');
+
+    expect(result.text).not.toContain('\x1b[');
+    expect(result.text).toContain('Created');
+  });
+
+  it('should format without ANSI colors for vscode IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'vscode';
+    const result = formatCreateResponse('new.js', 'const x = 1;', '/path/new.js');
+
+    expect(result.text).not.toContain('\x1b[');
+    expect(result.text).toContain('Created');
+  });
+
+  it('should truncate long files without ANSI colors for crush IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'crush';
+    const lines = Array(30).fill('line content').join('\n');
+    const result = formatCreateResponse('file.js', lines, '/path/file.js');
+
+    expect(result.text).toContain('lines hidden');
+    expect(result.text).not.toContain('\x1b[');
+  });
+
+  it('should show plural lines without colors for crush IDE', () => {
+    process.env.CEREBRAS_MCP_IDE = 'crush';
+    const result = formatCreateResponse('new.js', 'line1\nline2\nline3', '/path/new.js');
+
+    expect(result.text).toContain('3 lines');
+    expect(result.text).not.toContain('\x1b[');
   });
 });

--- a/tests/formatting/response-formatter.test.js
+++ b/tests/formatting/response-formatter.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { formatEditResponse, formatCreateResponse } from '../../src/formatting/response-formatter.js';
 
 describe('formatEditResponse', () => {

--- a/tests/formatting/response-formatter.test.js
+++ b/tests/formatting/response-formatter.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { formatEditResponse, formatCreateResponse } from '../../src/formatting/response-formatter.js';
+
+describe('formatEditResponse', () => {
+  it('should return null when no changes made', () => {
+    const result = formatEditResponse('file.js', 'same', 'same', '/path/file.js');
+    expect(result).toBeNull();
+  });
+
+  it('should format response for additions', () => {
+    const result = formatEditResponse('file.js', 'line1', 'line1\nline2', '/path/file.js');
+
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('text');
+    expect(result.text).toContain('Update');
+    expect(result.text).toContain('file.js');
+    expect(result.text).toContain('addition');
+  });
+
+  it('should format response for removals', () => {
+    const result = formatEditResponse('file.js', 'line1\nline2', 'line1', '/path/file.js');
+
+    expect(result).not.toBeNull();
+    expect(result.text).toContain('removal');
+  });
+
+  it('should count additions and removals correctly', () => {
+    const old = 'a\nb\nc';
+    const newContent = 'a\nx\ny\nc';
+    const result = formatEditResponse('file.js', old, newContent, '/path/file.js');
+
+    expect(result).not.toBeNull();
+    // x and y are added, b is removed
+    expect(result.text).toContain('addition');
+    expect(result.text).toContain('removal');
+  });
+
+  it('should handle empty lines in additions', () => {
+    const result = formatEditResponse('file.js', 'line1', 'line1\n\nline3', '/path/file.js');
+    expect(result).not.toBeNull();
+  });
+
+  it('should handle empty lines in removals', () => {
+    const result = formatEditResponse('file.js', 'line1\n\nline3', 'line1\nline3', '/path/file.js');
+    expect(result).not.toBeNull();
+  });
+
+  it('should include ANSI color codes', () => {
+    const result = formatEditResponse('file.js', 'old', 'new', '/path/file.js');
+
+    expect(result).not.toBeNull();
+    // Green for additions: \x1b[32m
+    expect(result.text).toContain('\x1b[32m');
+    // Red for removals: \x1b[31m
+    expect(result.text).toContain('\x1b[31m');
+  });
+});
+
+describe('formatCreateResponse', () => {
+  it('should format response for new file', () => {
+    const result = formatCreateResponse('new.js', 'const x = 1;', '/path/new.js');
+
+    expect(result.type).toBe('text');
+    expect(result.text).toContain('Create');
+    expect(result.text).toContain('new.js');
+    expect(result.text).toContain('1');
+    expect(result.text).toContain('line');
+  });
+
+  it('should handle multi-line content', () => {
+    const content = 'line1\nline2\nline3';
+    const result = formatCreateResponse('file.js', content, '/path/file.js');
+
+    expect(result.text).toContain('3');
+    expect(result.text).toContain('lines');
+  });
+
+  it('should show singular "line" for single line', () => {
+    const result = formatCreateResponse('file.js', 'single line', '/path/file.js');
+    expect(result.text).toMatch(/1.*line[^s]/);
+  });
+
+  it('should truncate very long files', () => {
+    // Create content with more than 50 lines
+    const lines = Array(60).fill('line content').join('\n');
+    const result = formatCreateResponse('file.js', lines, '/path/file.js');
+
+    expect(result.text).toContain('lines hidden');
+  });
+
+  it('should include line numbers', () => {
+    const result = formatCreateResponse('file.js', 'line1\nline2\nline3', '/path/file.js');
+
+    expect(result.text).toMatch(/\s+1\s/);
+    expect(result.text).toMatch(/\s+2\s/);
+    expect(result.text).toMatch(/\s+3\s/);
+  });
+
+  it('should handle empty lines in content', () => {
+    const result = formatCreateResponse('file.js', 'line1\n\nline3', '/path/file.js');
+    expect(result).not.toBeNull();
+    expect(result.text).toContain('3');
+  });
+
+  it('should include green color for additions', () => {
+    const result = formatCreateResponse('file.js', 'content', '/path/file.js');
+    expect(result.text).toContain('\x1b[32m');
+  });
+});

--- a/tests/formatting/syntax-highlighter.test.js
+++ b/tests/formatting/syntax-highlighter.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { syntaxHighlight } from '../../src/formatting/syntax-highlighter.js';
+
+describe('syntaxHighlight', () => {
+  const ANSI = {
+    keyword: '\x1b[35m',
+    string: '\x1b[33m',
+    comment: '\x1b[90m',
+    number: '\x1b[36m',
+    function: '\x1b[34m',
+    reset: '\x1b[0m'
+  };
+
+  describe('JavaScript', () => {
+    it('should highlight keywords', () => {
+      const result = syntaxHighlight('const x = 5;', 'javascript');
+      expect(result).toContain(`${ANSI.keyword}const${ANSI.reset}`);
+    });
+
+    it('should highlight strings', () => {
+      const result = syntaxHighlight('const name = "hello";', 'javascript');
+      expect(result).toContain(`${ANSI.string}"hello"${ANSI.reset}`);
+    });
+
+    it('should highlight single-quoted strings', () => {
+      const result = syntaxHighlight("const name = 'world';", 'javascript');
+      expect(result).toContain(`${ANSI.string}'world'${ANSI.reset}`);
+    });
+
+    it('should highlight numbers', () => {
+      const result = syntaxHighlight('const x = 42;', 'javascript');
+      expect(result).toContain(`${ANSI.number}42${ANSI.reset}`);
+    });
+
+    it('should highlight decimal numbers', () => {
+      const result = syntaxHighlight('const pi = 3.14;', 'javascript');
+      expect(result).toContain(`${ANSI.number}3.14${ANSI.reset}`);
+    });
+
+    it('should highlight // comments', () => {
+      const result = syntaxHighlight('x = 1; // comment', 'javascript');
+      expect(result).toContain(`${ANSI.comment}// comment${ANSI.reset}`);
+    });
+
+    it('should highlight /* */ comments', () => {
+      const result = syntaxHighlight('x = 1; /* block */', 'javascript');
+      expect(result).toContain(`${ANSI.comment}/* block */${ANSI.reset}`);
+    });
+
+    it('should highlight function calls', () => {
+      const result = syntaxHighlight('myFunction()', 'javascript');
+      expect(result).toContain(`${ANSI.function}myFunction${ANSI.reset}(`);
+    });
+
+    it('should highlight multiple keywords', () => {
+      const result = syntaxHighlight('async function test() { return await promise; }', 'javascript');
+      expect(result).toContain(`${ANSI.keyword}async${ANSI.reset}`);
+      expect(result).toContain(`${ANSI.keyword}function${ANSI.reset}`);
+      expect(result).toContain(`${ANSI.keyword}return${ANSI.reset}`);
+      expect(result).toContain(`${ANSI.keyword}await${ANSI.reset}`);
+    });
+
+    it('should handle multi-line code', () => {
+      const code = 'const a = 1;\nconst b = 2;';
+      const result = syntaxHighlight(code, 'javascript');
+      const lines = result.split('\n');
+      expect(lines.length).toBe(2);
+      expect(lines[0]).toContain(`${ANSI.keyword}const${ANSI.reset}`);
+      expect(lines[1]).toContain(`${ANSI.keyword}const${ANSI.reset}`);
+    });
+  });
+
+  describe('Python', () => {
+    it('should highlight Python keywords', () => {
+      const result = syntaxHighlight('def foo(): return True', 'python');
+      expect(result).toContain(`${ANSI.keyword}def${ANSI.reset}`);
+      expect(result).toContain(`${ANSI.keyword}return${ANSI.reset}`);
+      expect(result).toContain(`${ANSI.keyword}True${ANSI.reset}`);
+    });
+
+    it('should highlight Python # comments', () => {
+      const result = syntaxHighlight('x = 1  # comment', 'python');
+      expect(result).toContain(`${ANSI.comment}# comment${ANSI.reset}`);
+    });
+
+    it('should highlight function calls in Python', () => {
+      const result = syntaxHighlight('print("hello")', 'python');
+      expect(result).toContain(`${ANSI.function}print${ANSI.reset}(`);
+    });
+  });
+
+  describe('HTML', () => {
+    it('should highlight HTML tags (as keywords)', () => {
+      const result = syntaxHighlight('<div><span></span></div>', 'html');
+      expect(result).toContain(`${ANSI.keyword}div${ANSI.reset}`);
+      expect(result).toContain(`${ANSI.keyword}span${ANSI.reset}`);
+    });
+
+    it('should highlight HTML comments', () => {
+      const result = syntaxHighlight('<!-- comment -->', 'html');
+      expect(result).toContain(`${ANSI.comment}<!-- comment -->${ANSI.reset}`);
+    });
+  });
+
+  describe('CSS', () => {
+    it('should highlight CSS properties', () => {
+      const result = syntaxHighlight('color: red; margin: 10px;', 'css');
+      expect(result).toContain(`${ANSI.keyword}color${ANSI.reset}`);
+      expect(result).toContain(`${ANSI.keyword}margin${ANSI.reset}`);
+    });
+
+    it('should highlight CSS comments', () => {
+      const result = syntaxHighlight('/* style */ color: blue;', 'css');
+      expect(result).toContain(`${ANSI.comment}/* style */${ANSI.reset}`);
+    });
+  });
+
+  describe('Unknown language', () => {
+    it('should still highlight strings and numbers', () => {
+      const result = syntaxHighlight('x = "hello" + 42', 'unknown');
+      expect(result).toContain(`${ANSI.string}"hello"${ANSI.reset}`);
+      expect(result).toContain(`${ANSI.number}42${ANSI.reset}`);
+    });
+
+    it('should not highlight keywords for unknown language', () => {
+      const result = syntaxHighlight('const x = 1;', 'unknown');
+      expect(result).not.toContain(`${ANSI.keyword}const${ANSI.reset}`);
+    });
+  });
+});

--- a/tests/integration/helpers/setup.js
+++ b/tests/integration/helpers/setup.js
@@ -1,0 +1,56 @@
+import { config } from '../../../src/config/constants.js';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Force the router to use a specific provider by manipulating config keys.
+ * Returns a restore function to call in afterAll/afterEach.
+ */
+export function forceProvider(provider) {
+  const saved = {
+    cerebrasApiKey: config.cerebrasApiKey,
+    openRouterApiKey: config.openRouterApiKey,
+  };
+
+  if (provider === 'cerebras') {
+    config.openRouterApiKey = '';
+  } else if (provider === 'openrouter') {
+    config.cerebrasApiKey = '';
+  }
+
+  return () => Object.assign(config, saved);
+}
+
+/**
+ * Force the Cerebras → OpenRouter fallback path by setting an invalid
+ * Cerebras key (truthy so the router picks it as primary, but the API
+ * call will fail) while keeping the real OpenRouter key intact.
+ * Returns a restore function.
+ */
+export function forceFallback() {
+  const saved = { cerebrasApiKey: config.cerebrasApiKey };
+  config.cerebrasApiKey = 'invalid-key';
+  return () => Object.assign(config, saved);
+}
+
+/**
+ * Check if a provider's API key is available.
+ */
+export function hasProvider(provider) {
+  if (provider === 'cerebras') return !!process.env.CEREBRAS_API_KEY;
+  if (provider === 'openrouter') return !!process.env.OPENROUTER_API_KEY;
+  return false;
+}
+
+/**
+ * Create a temporary directory for integration test file output.
+ * Returns { dir, cleanup } where cleanup removes the directory.
+ */
+export async function createTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cerebras-mcp-test-'));
+  return {
+    dir,
+    cleanup: () => fs.rm(dir, { recursive: true, force: true }),
+  };
+}

--- a/tests/integration/write.integration.test.js
+++ b/tests/integration/write.integration.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+import { handleWriteTool } from '../../src/server/tool-handlers.js';
+import { forceProvider, forceFallback, hasProvider, createTempDir } from './helpers/setup.js';
+
+// Available providers based on env vars present
+const providers = [
+  hasProvider('cerebras') && 'cerebras',
+  hasProvider('openrouter') && 'openrouter',
+].filter(Boolean);
+
+describe.skipIf(providers.length === 0)('Integration: write tool', () => {
+  let tempDir, cleanup;
+
+  beforeAll(async () => {
+    ({ dir: tempDir, cleanup } = await createTempDir());
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  describe.each(providers)('provider: %s', (provider) => {
+    let restore;
+
+    beforeAll(() => {
+      restore = forceProvider(provider);
+    });
+
+    afterAll(() => restore());
+
+    it('should generate a hello world function', async () => {
+      const filePath = path.join(tempDir, `hello-${provider}.js`);
+
+      const result = await handleWriteTool({
+        file_path: filePath,
+        prompt: 'Create a function called helloWorld that returns the string "hello world"',
+      });
+
+      // Tool should return content (not an error)
+      expect(result.content).toBeDefined();
+      expect(result.content.length).toBeGreaterThan(0);
+
+      // The first content item should be text (diff or create output)
+      const text = result.content[0].text;
+      expect(text).toBeDefined();
+
+      // File should have been written
+      const written = await fs.readFile(filePath, 'utf-8');
+      expect(written).toContain('helloWorld');
+      expect(written).toMatch(/hello.world/i);
+    }, 30_000);
+  });
+
+  const canTestFallback = hasProvider('cerebras') && hasProvider('openrouter');
+
+  describe.skipIf(!canTestFallback)('fallback: cerebras → openrouter', () => {
+    let restore;
+
+    beforeAll(() => {
+      restore = forceFallback();
+    });
+
+    afterAll(() => restore());
+
+    it('should fall back to openrouter when cerebras fails', async () => {
+      const filePath = path.join(tempDir, 'hello-fallback.js');
+
+      const result = await handleWriteTool({
+        file_path: filePath,
+        prompt: 'Create a function called helloWorld that returns the string "hello world"',
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content.length).toBeGreaterThan(0);
+
+      const text = result.content[0].text;
+      expect(text).toBeDefined();
+
+      const written = await fs.readFile(filePath, 'utf-8');
+      expect(written).toContain('helloWorld');
+      expect(written).toMatch(/hello.world/i);
+    }, 30_000);
+  });
+});

--- a/tests/integration/write.integration.test.js
+++ b/tests/integration/write.integration.test.js
@@ -173,51 +173,62 @@ describe.skipIf(providers.length === 0)('Integration: write tool', () => {
     }, 30_000);
   });
 
-  describe('error handling', () => {
-    it('should return structured error when prompt is missing', async () => {
-      const filePath = path.join(tempDir, 'error-no-prompt.js');
+});
 
-      const result = await handleWriteTool({
-        file_path: filePath,
-      });
+describe('Integration: error handling (no API keys required)', () => {
+  let tempDir, cleanup;
 
-      expect(result.content).toBeDefined();
-      expect(result.content[0].text).toMatch(/prompt is required/i);
-
-      // File should not have been created
-      await expect(fs.access(filePath)).rejects.toThrow();
-    });
-
-    it('should return structured error when file_path is missing', async () => {
-      const result = await handleWriteTool({
-        prompt: 'Create something',
-      });
-
-      expect(result.content).toBeDefined();
-      expect(result.content[0].text).toMatch(/file_path is required/i);
-    });
-
-    it('should return structured error with invalid API key', async () => {
-      const savedCerebras = config.cerebrasApiKey;
-      const savedOpenRouter = config.openRouterApiKey;
-      config.cerebrasApiKey = 'invalid-key-xxx';
-      config.openRouterApiKey = '';
-
-      const filePath = path.join(tempDir, 'should-not-exist.js');
-
-      const result = await handleWriteTool({
-        file_path: filePath,
-        prompt: 'Create a hello world function',
-      });
-
-      config.cerebrasApiKey = savedCerebras;
-      config.openRouterApiKey = savedOpenRouter;
-
-      expect(result.content).toBeDefined();
-      expect(result.content[0].text).toMatch(/error/i);
-
-      // File should not have been created (API failed before write)
-      await expect(fs.access(filePath)).rejects.toThrow();
-    }, 30_000);
+  beforeAll(async () => {
+    ({ dir: tempDir, cleanup } = await createTempDir());
   });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('should return structured error when prompt is missing', async () => {
+    const filePath = path.join(tempDir, 'error-no-prompt.js');
+
+    const result = await handleWriteTool({
+      file_path: filePath,
+    });
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].text).toMatch(/prompt is required/i);
+
+    // File should not have been created
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it('should return structured error when file_path is missing', async () => {
+    const result = await handleWriteTool({
+      prompt: 'Create something',
+    });
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].text).toMatch(/file_path is required/i);
+  });
+
+  it('should return structured error with invalid API key', async () => {
+    const savedCerebras = config.cerebrasApiKey;
+    const savedOpenRouter = config.openRouterApiKey;
+    config.cerebrasApiKey = 'invalid-key-xxx';
+    config.openRouterApiKey = '';
+
+    const filePath = path.join(tempDir, 'should-not-exist.js');
+
+    const result = await handleWriteTool({
+      file_path: filePath,
+      prompt: 'Create a hello world function',
+    });
+
+    config.cerebrasApiKey = savedCerebras;
+    config.openRouterApiKey = savedOpenRouter;
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].text).toMatch(/error/i);
+
+    // File should not have been created (API failed before write)
+    await expect(fs.access(filePath)).rejects.toThrow();
+  }, 30_000);
 });

--- a/tests/integration/write.integration.test.js
+++ b/tests/integration/write.integration.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import path from 'path';
 import fs from 'fs/promises';
 import { handleWriteTool } from '../../src/server/tool-handlers.js';
+import { config } from '../../src/config/constants.js';
 import { forceProvider, forceFallback, hasProvider, createTempDir } from './helpers/setup.js';
 
 // Available providers based on env vars present
@@ -53,6 +54,94 @@ describe.skipIf(providers.length === 0)('Integration: write tool', () => {
     }, 30_000);
   });
 
+  describe.each(providers)('edit existing file: %s', (provider) => {
+    let restore;
+
+    beforeAll(() => {
+      restore = forceProvider(provider);
+    });
+
+    afterAll(() => restore());
+
+    it('should edit an existing file and return a diff', async () => {
+      const filePath = path.join(tempDir, `edit-${provider}.js`);
+      const seed = `function greet(name) {\n  // TODO: implement greeting\n  return '';\n}`;
+      await fs.writeFile(filePath, seed);
+
+      const result = await handleWriteTool({
+        file_path: filePath,
+        prompt: 'Implement the greet function to return "Hello, " concatenated with the name parameter',
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content.length).toBeGreaterThan(0);
+
+      const text = result.content[0].text;
+      expect(text).toMatch(/update/i);
+
+      const written = await fs.readFile(filePath, 'utf-8');
+      expect(written).not.toBe(seed);
+      expect(written).toMatch(/function/i);
+    }, 30_000);
+  });
+
+  describe('context files', () => {
+    let restore;
+    const contextProvider = providers[0];
+
+    beforeAll(() => {
+      restore = forceProvider(contextProvider);
+    });
+
+    afterAll(() => restore());
+
+    it('should use context files to inform code generation', async () => {
+      const contextPath = path.join(tempDir, 'context-helper.js');
+      const contextContent = `export function formatName(first, last) {\n  return \`\${first} \${last}\`;\n}`;
+      await fs.writeFile(contextPath, contextContent);
+
+      const outputPath = path.join(tempDir, 'context-output.js');
+
+      const result = await handleWriteTool({
+        file_path: outputPath,
+        prompt: 'Create a greetUser function that imports and uses the formatName function from the context file to greet a user by full name',
+        context_files: [contextPath],
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content.length).toBeGreaterThan(0);
+
+      const written = await fs.readFile(outputPath, 'utf-8');
+      expect(written).toContain('formatName');
+    }, 30_000);
+  });
+
+  describe('nested directory creation', () => {
+    let restore;
+    const nestedProvider = providers[0];
+
+    beforeAll(() => {
+      restore = forceProvider(nestedProvider);
+    });
+
+    afterAll(() => restore());
+
+    it('should create parent directories when they do not exist', async () => {
+      const filePath = path.join(tempDir, 'nested', 'deep', 'dir', 'output.js');
+
+      const result = await handleWriteTool({
+        file_path: filePath,
+        prompt: 'Create a function called hello that returns the string "world"',
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content.length).toBeGreaterThan(0);
+
+      const written = await fs.readFile(filePath, 'utf-8');
+      expect(written).toMatch(/hello|world/i);
+    }, 30_000);
+  });
+
   const canTestFallback = hasProvider('cerebras') && hasProvider('openrouter');
 
   describe.skipIf(!canTestFallback)('fallback: cerebras → openrouter', () => {
@@ -81,6 +170,54 @@ describe.skipIf(providers.length === 0)('Integration: write tool', () => {
       const written = await fs.readFile(filePath, 'utf-8');
       expect(written).toContain('helloWorld');
       expect(written).toMatch(/hello.world/i);
+    }, 30_000);
+  });
+
+  describe('error handling', () => {
+    it('should return structured error when prompt is missing', async () => {
+      const filePath = path.join(tempDir, 'error-no-prompt.js');
+
+      const result = await handleWriteTool({
+        file_path: filePath,
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toMatch(/prompt is required/i);
+
+      // File should not have been created
+      await expect(fs.access(filePath)).rejects.toThrow();
+    });
+
+    it('should return structured error when file_path is missing', async () => {
+      const result = await handleWriteTool({
+        prompt: 'Create something',
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toMatch(/file_path is required/i);
+    });
+
+    it('should return structured error with invalid API key', async () => {
+      const savedCerebras = config.cerebrasApiKey;
+      const savedOpenRouter = config.openRouterApiKey;
+      config.cerebrasApiKey = 'invalid-key-xxx';
+      config.openRouterApiKey = '';
+
+      const filePath = path.join(tempDir, 'should-not-exist.js');
+
+      const result = await handleWriteTool({
+        file_path: filePath,
+        prompt: 'Create a hello world function',
+      });
+
+      config.cerebrasApiKey = savedCerebras;
+      config.openRouterApiKey = savedOpenRouter;
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toMatch(/error/i);
+
+      // File should not have been created (API failed before write)
+      await expect(fs.access(filePath)).rejects.toThrow();
     }, 30_000);
   });
 });

--- a/tests/server/mcp-server.test.js
+++ b/tests/server/mcp-server.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockServer = vi.hoisted(() => ({
+  setRequestHandler: vi.fn(),
+  connect: vi.fn()
+}));
+
+const mockTransportInstance = vi.hoisted(() => ({}));
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
+  Server: class {
+    constructor() {
+      Object.assign(this, mockServer);
+    }
+  }
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: class {
+    constructor() {
+      Object.assign(this, mockTransportInstance);
+    }
+  }
+}));
+
+vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
+  ListToolsRequestSchema: 'ListToolsRequestSchema',
+  CallToolRequestSchema: 'CallToolRequestSchema'
+}));
+
+const mockHandleWriteTool = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/server/tool-handlers.js', () => ({
+  handleWriteTool: mockHandleWriteTool
+}));
+
+import { server, startServer } from '../../src/server/mcp-server.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+describe('server', () => {
+  it('should create server with setRequestHandler method', () => {
+    expect(server.setRequestHandler).toBeDefined();
+    expect(server.connect).toBeDefined();
+  });
+
+  it('should register ListToolsRequestSchema handler', () => {
+    expect(mockServer.setRequestHandler).toHaveBeenCalledWith(
+      ListToolsRequestSchema,
+      expect.any(Function)
+    );
+  });
+
+  it('should register CallToolRequestSchema handler', () => {
+    expect(mockServer.setRequestHandler).toHaveBeenCalledWith(
+      CallToolRequestSchema,
+      expect.any(Function)
+    );
+  });
+});
+
+describe('ListToolsRequestSchema handler', () => {
+  let listToolsHandler;
+
+  beforeEach(() => {
+    listToolsHandler = mockServer.setRequestHandler.mock.calls.find(
+      call => call[0] === ListToolsRequestSchema
+    )?.[1];
+  });
+
+  it('should return tools array with write tool', async () => {
+    const result = await listToolsHandler();
+    expect(result).toHaveProperty('tools');
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]).toMatchObject({
+      name: 'write',
+      description: expect.stringContaining('MANDATORY CODE TOOL')
+    });
+    expect(result.tools[0].inputSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        file_path: { type: 'string' },
+        prompt: { type: 'string' },
+        context_files: { type: 'array' }
+      },
+      required: ['file_path', 'prompt']
+    });
+  });
+});
+
+describe('CallToolRequestSchema handler', () => {
+  let callToolHandler;
+
+  beforeEach(() => {
+    callToolHandler = mockServer.setRequestHandler.mock.calls.find(
+      call => call[0] === CallToolRequestSchema
+    )?.[1];
+  });
+
+  it('should call handleWriteTool for write tool', async () => {
+    const args = { file_path: '/test/file.js', prompt: 'test prompt' };
+    await callToolHandler({ params: { name: 'write', arguments: args } });
+    expect(mockHandleWriteTool).toHaveBeenCalledWith(args);
+  });
+
+  it('should throw error for unknown tool', async () => {
+    await expect(
+      callToolHandler({ params: { name: 'unknown', arguments: {} } })
+    ).rejects.toThrow('Unknown tool: unknown');
+  });
+});
+
+describe('startServer', () => {
+  it('should connect server', async () => {
+    await startServer();
+    expect(mockServer.connect).toHaveBeenCalled();
+  });
+
+  it('should return server instance', async () => {
+    const result = await startServer();
+    expect(result).toBeDefined();
+    expect(result.setRequestHandler).toBeDefined();
+  });
+});

--- a/tests/server/tool-handlers.test.js
+++ b/tests/server/tool-handlers.test.js
@@ -24,7 +24,7 @@ vi.mock('../../src/formatting/response-formatter.js', () => ({
 }));
 
 import { readFileContent, writeFileContent } from '../../src/utils/file-utils.js';
-import { cleanCodeResponse } from '../../src/utils/code-cleaner.js';
+// cleanCodeResponse is mocked but not directly referenced in tests
 import { routeAPICall } from '../../src/api/router/router.js';
 import { formatEditResponse, formatCreateResponse } from '../../src/formatting/response-formatter.js';
 
@@ -76,7 +76,7 @@ describe('handleWriteTool', () => {
       text: 'Updated file'
     });
 
-    const result = await handleWriteTool({
+    await handleWriteTool({
       file_path: '/path/existing.js',
       prompt: 'update the function'
     });

--- a/tests/server/tool-handlers.test.js
+++ b/tests/server/tool-handlers.test.js
@@ -136,4 +136,20 @@ describe('handleWriteTool', () => {
 
     expect(result.content).toHaveLength(0);
   });
+
+  it('should return empty content when existing file is empty', async () => {
+    vi.mocked(readFileContent).mockResolvedValue('');
+    vi.mocked(routeAPICall).mockResolvedValue('new code');
+    vi.mocked(writeFileContent).mockResolvedValue(true);
+
+    const result = await handleWriteTool({
+      file_path: '/path/empty.js',
+      prompt: 'write code'
+    });
+
+    expect(writeFileContent).toHaveBeenCalledWith('/path/empty.js', 'new code');
+    expect(formatEditResponse).not.toHaveBeenCalled();
+    expect(formatCreateResponse).not.toHaveBeenCalled();
+    expect(result.content).toHaveLength(0);
+  });
 });

--- a/tests/server/tool-handlers.test.js
+++ b/tests/server/tool-handlers.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleWriteTool } from '../../src/server/tool-handlers.js';
+
+vi.mock('../../src/config/constants.js', () => ({
+  debugLog: vi.fn()
+}));
+
+vi.mock('../../src/utils/file-utils.js', () => ({
+  readFileContent: vi.fn(),
+  writeFileContent: vi.fn()
+}));
+
+vi.mock('../../src/utils/code-cleaner.js', () => ({
+  cleanCodeResponse: vi.fn(code => code)
+}));
+
+vi.mock('../../src/api/router/router.js', () => ({
+  routeAPICall: vi.fn()
+}));
+
+vi.mock('../../src/formatting/response-formatter.js', () => ({
+  formatEditResponse: vi.fn(),
+  formatCreateResponse: vi.fn()
+}));
+
+import { readFileContent, writeFileContent } from '../../src/utils/file-utils.js';
+import { cleanCodeResponse } from '../../src/utils/code-cleaner.js';
+import { routeAPICall } from '../../src/api/router/router.js';
+import { formatEditResponse, formatCreateResponse } from '../../src/formatting/response-formatter.js';
+
+describe('handleWriteTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return error when prompt is missing', async () => {
+    const result = await handleWriteTool({ file_path: '/path/file.js' });
+
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Prompt is required');
+  });
+
+  it('should return error when file_path is missing', async () => {
+    const result = await handleWriteTool({ prompt: 'write code' });
+
+    expect(result.content[0].text).toContain('file_path is required');
+  });
+
+  it('should create new file when file does not exist', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    vi.mocked(routeAPICall).mockResolvedValue('generated code');
+    vi.mocked(writeFileContent).mockResolvedValue(true);
+    vi.mocked(formatCreateResponse).mockReturnValue({
+      type: 'text',
+      text: 'Created file'
+    });
+
+    const result = await handleWriteTool({
+      file_path: '/path/new.js',
+      prompt: 'create a function'
+    });
+
+    expect(readFileContent).toHaveBeenCalledWith('/path/new.js');
+    expect(routeAPICall).toHaveBeenCalled();
+    expect(writeFileContent).toHaveBeenCalledWith('/path/new.js', 'generated code');
+    expect(formatCreateResponse).toHaveBeenCalledWith('new.js', 'generated code', '/path/new.js');
+    expect(result.content).toHaveLength(1);
+  });
+
+  it('should edit existing file', async () => {
+    vi.mocked(readFileContent).mockResolvedValue('existing content');
+    vi.mocked(routeAPICall).mockResolvedValue('updated content');
+    vi.mocked(writeFileContent).mockResolvedValue(true);
+    vi.mocked(formatEditResponse).mockReturnValue({
+      type: 'text',
+      text: 'Updated file'
+    });
+
+    const result = await handleWriteTool({
+      file_path: '/path/existing.js',
+      prompt: 'update the function'
+    });
+
+    expect(formatEditResponse).toHaveBeenCalledWith(
+      'existing.js',
+      'existing content',
+      'updated content',
+      '/path/existing.js'
+    );
+  });
+
+  it('should pass context_files to routeAPICall', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    vi.mocked(routeAPICall).mockResolvedValue('code');
+    vi.mocked(writeFileContent).mockResolvedValue(true);
+    vi.mocked(formatCreateResponse).mockReturnValue({ type: 'text', text: 'ok' });
+
+    await handleWriteTool({
+      file_path: '/path/file.js',
+      prompt: 'write code',
+      context_files: ['/context/file1.js', '/context/file2.js']
+    });
+
+    expect(routeAPICall).toHaveBeenCalledWith(
+      'write code',
+      '',
+      '/path/file.js',
+      null,
+      ['/context/file1.js', '/context/file2.js']
+    );
+  });
+
+  it('should handle API errors gracefully', async () => {
+    vi.mocked(readFileContent).mockResolvedValue(null);
+    vi.mocked(routeAPICall).mockRejectedValue(new Error('API failed'));
+
+    const result = await handleWriteTool({
+      file_path: '/path/file.js',
+      prompt: 'write code'
+    });
+
+    expect(result.content[0].text).toContain('Error');
+    expect(result.content[0].text).toContain('API failed');
+  });
+
+  it('should handle null formatEditResponse', async () => {
+    vi.mocked(readFileContent).mockResolvedValue('old');
+    vi.mocked(routeAPICall).mockResolvedValue('old'); // No change
+    vi.mocked(writeFileContent).mockResolvedValue(true);
+    vi.mocked(formatEditResponse).mockReturnValue(null);
+
+    const result = await handleWriteTool({
+      file_path: '/path/file.js',
+      prompt: 'update'
+    });
+
+    expect(result.content).toHaveLength(0);
+  });
+});

--- a/tests/utils/code-cleaner.test.js
+++ b/tests/utils/code-cleaner.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { cleanCodeResponse } from '../../src/utils/code-cleaner.js';
+
+describe('cleanCodeResponse', () => {
+  it('should return null/undefined unchanged', () => {
+    expect(cleanCodeResponse(null)).toBe(null);
+    expect(cleanCodeResponse(undefined)).toBe(undefined);
+  });
+
+  it('should return empty string unchanged', () => {
+    expect(cleanCodeResponse('')).toBe('');
+  });
+
+  it('should return plain text trimmed when no code blocks', () => {
+    expect(cleanCodeResponse('  hello world  ')).toBe('hello world');
+  });
+
+  it('should extract code from single code block with language', () => {
+    const input = '```javascript\nconst x = 5;\n```';
+    expect(cleanCodeResponse(input)).toBe('const x = 5;');
+  });
+
+  it('should extract code from code block without language', () => {
+    const input = '```\nconst x = 5;\n```';
+    expect(cleanCodeResponse(input)).toBe('const x = 5;');
+  });
+
+  it('should return first code block when multiple present', () => {
+    const input = '```javascript\nconst first = 1;\n```\n```javascript\nconst second = 2;\n```';
+    expect(cleanCodeResponse(input)).toBe('const first = 1;');
+  });
+
+  it('should strip language identifier on its own line', () => {
+    const input = '```\npython\nprint("hello")\n```';
+    expect(cleanCodeResponse(input)).toBe('print("hello")');
+  });
+
+  it('should not strip content that looks like language but is code', () => {
+    const input = '```javascript\nconst python = "snake";\n```';
+    expect(cleanCodeResponse(input)).toBe('const python = "snake";');
+  });
+
+  it('should handle code block with extra whitespace', () => {
+    const input = '```javascript\n\n  const x = 5;  \n\n```';
+    expect(cleanCodeResponse(input)).toBe('const x = 5;');
+  });
+
+  it('should handle fallback path with partial markdown', () => {
+    const input = '```javascript\nconst x = 5;';
+    // No closing ```, falls back to regex cleanup
+    const result = cleanCodeResponse(input);
+    expect(result).toBe('const x = 5;');
+  });
+
+  it('should handle text surrounding code block', () => {
+    const input = 'Here is the code:\n```javascript\nconst x = 5;\n```\nThat was the code.';
+    expect(cleanCodeResponse(input)).toBe('const x = 5;');
+  });
+
+  it('should strip language identifier in fallback path without code blocks', () => {
+    // No code blocks, just a language identifier on first line
+    const input = 'javascript\nconsole.log("hello");';
+    expect(cleanCodeResponse(input)).toBe('console.log("hello");');
+  });
+});

--- a/tests/utils/file-utils.test.js
+++ b/tests/utils/file-utils.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileContent, writeFileContent, getLanguageFromFile } from '../../src/utils/file-utils.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+// Mock fs/promises
+vi.mock('fs/promises');
+
+describe('getLanguageFromFile', () => {
+  it('should return explicit language when provided', () => {
+    expect(getLanguageFromFile('test.py', 'javascript')).toBe('javascript');
+    expect(getLanguageFromFile('test.js', 'PYTHON')).toBe('python');
+  });
+
+  it('should detect Python files', () => {
+    expect(getLanguageFromFile('app.py')).toBe('python');
+  });
+
+  it('should detect JavaScript files', () => {
+    expect(getLanguageFromFile('app.js')).toBe('javascript');
+    expect(getLanguageFromFile('component.jsx')).toBe('javascript');
+  });
+
+  it('should detect TypeScript files', () => {
+    expect(getLanguageFromFile('app.ts')).toBe('typescript');
+    expect(getLanguageFromFile('component.tsx')).toBe('typescript');
+  });
+
+  it('should detect various languages', () => {
+    expect(getLanguageFromFile('Main.java')).toBe('java');
+    expect(getLanguageFromFile('main.cpp')).toBe('cpp');
+    expect(getLanguageFromFile('main.c')).toBe('c');
+    expect(getLanguageFromFile('Program.cs')).toBe('csharp');
+    expect(getLanguageFromFile('main.go')).toBe('go');
+    expect(getLanguageFromFile('main.rs')).toBe('rust');
+    expect(getLanguageFromFile('app.rb')).toBe('ruby');
+    expect(getLanguageFromFile('script.sh')).toBe('bash');
+    expect(getLanguageFromFile('query.sql')).toBe('sql');
+  });
+
+  it('should detect web languages', () => {
+    expect(getLanguageFromFile('index.html')).toBe('html');
+    expect(getLanguageFromFile('styles.css')).toBe('css');
+    expect(getLanguageFromFile('styles.scss')).toBe('scss');
+    expect(getLanguageFromFile('styles.less')).toBe('less');
+  });
+
+  it('should detect data formats', () => {
+    expect(getLanguageFromFile('data.json')).toBe('json');
+    expect(getLanguageFromFile('config.xml')).toBe('xml');
+    expect(getLanguageFromFile('config.yaml')).toBe('yaml');
+    expect(getLanguageFromFile('config.yml')).toBe('yaml');
+  });
+
+  it('should return text for unknown extensions', () => {
+    expect(getLanguageFromFile('readme.md')).toBe('text');
+    expect(getLanguageFromFile('file.unknown')).toBe('text');
+    expect(getLanguageFromFile('noextension')).toBe('text');
+  });
+
+  it('should handle uppercase extensions', () => {
+    expect(getLanguageFromFile('app.JS')).toBe('javascript');
+    expect(getLanguageFromFile('app.PY')).toBe('python');
+  });
+});
+
+describe('readFileContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should read file with absolute path', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue('file content');
+
+    const result = await readFileContent('/absolute/path/file.js');
+
+    expect(result).toBe('file content');
+    expect(fs.readFile).toHaveBeenCalledWith('/absolute/path/file.js', 'utf-8');
+  });
+
+  it('should expand home path', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue('home file');
+    const originalHome = process.env.HOME;
+    process.env.HOME = '/home/testuser';
+
+    const result = await readFileContent('~/documents/file.js');
+
+    expect(result).toBe('home file');
+    expect(fs.readFile).toHaveBeenCalledWith('/home/testuser/documents/file.js', 'utf-8');
+
+    process.env.HOME = originalHome;
+  });
+
+  it('should convert relative path to absolute', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue('relative content');
+
+    const result = await readFileContent('src/file.js');
+
+    expect(result).toBe('relative content');
+    expect(fs.readFile).toHaveBeenCalledWith(path.join(process.cwd(), 'src/file.js'), 'utf-8');
+  });
+
+  it('should return null for non-existent file', async () => {
+    const error = new Error('File not found');
+    error.code = 'ENOENT';
+    vi.mocked(fs.readFile).mockRejectedValue(error);
+
+    const result = await readFileContent('/nonexistent/file.js');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw error for other read failures', async () => {
+    const error = new Error('Permission denied');
+    error.code = 'EACCES';
+    vi.mocked(fs.readFile).mockRejectedValue(error);
+
+    await expect(readFileContent('/protected/file.js'))
+      .rejects.toThrow('Failed to read file /protected/file.js: Permission denied');
+  });
+});
+
+describe('writeFileContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+  });
+
+  it('should write file with absolute path', async () => {
+    const result = await writeFileContent('/absolute/path/file.js', 'content');
+
+    expect(result).toBe(true);
+    expect(fs.mkdir).toHaveBeenCalledWith('/absolute/path', { recursive: true });
+    expect(fs.writeFile).toHaveBeenCalledWith('/absolute/path/file.js', 'content', 'utf-8');
+  });
+
+  it('should expand home path for writing', async () => {
+    const originalHome = process.env.HOME;
+    process.env.HOME = '/home/testuser';
+
+    const result = await writeFileContent('~/documents/file.js', 'content');
+
+    expect(result).toBe(true);
+    expect(fs.mkdir).toHaveBeenCalledWith('/home/testuser/documents', { recursive: true });
+    expect(fs.writeFile).toHaveBeenCalledWith('/home/testuser/documents/file.js', 'content', 'utf-8');
+
+    process.env.HOME = originalHome;
+  });
+
+  it('should convert relative path for writing', async () => {
+    const result = await writeFileContent('src/file.js', 'content');
+
+    expect(result).toBe(true);
+    const expectedPath = path.join(process.cwd(), 'src/file.js');
+    expect(fs.writeFile).toHaveBeenCalledWith(expectedPath, 'content', 'utf-8');
+  });
+
+  it('should throw error on write failure', async () => {
+    vi.mocked(fs.writeFile).mockRejectedValue(new Error('Disk full'));
+
+    await expect(writeFileContent('/path/file.js', 'content'))
+      .rejects.toThrow('Failed to write file /path/file.js: Disk full');
+  });
+
+  it('should create directory if it does not exist', async () => {
+    await writeFileContent('/new/nested/dir/file.js', 'content');
+
+    expect(fs.mkdir).toHaveBeenCalledWith('/new/nested/dir', { recursive: true });
+  });
+});

--- a/tests/utils/file-utils.test.js
+++ b/tests/utils/file-utils.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileContent, writeFileContent, getLanguageFromFile } from '../../src/utils/file-utils.js';
 import fs from 'fs/promises';
 import path from 'path';

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.js'],
+      exclude: ['src/index.js'],
+    },
+  },
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       include: ['src/**/*.js'],
-      exclude: ['src/index.js'],
+      exclude: ['src/index.js', 'src/config/interactive-config.js'],
     },
   },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.js'],
+    exclude: ['tests/integration/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],

--- a/vitest.integration.config.js
+++ b/vitest.integration.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/integration/**/*.test.js'],
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary
  - Updated default model to zai-glm-4.7                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
  - Add dev tooling: Vitest for unit/integration testing, ESLint for linting, Prettier for formatting
  - Add 155 unit tests (11 test files) and 10 integration tests covering all `src/` modules at 99%+ coverage                                                                                                                                                                                                                                                                                                                                                                                                                  
  - Fix hardcoded provider pinning in OpenRouter requests and update deprecated default model (Qwen 3 Coder)
  - Add `OPENROUTER_MODEL` env var support for configurable model selection
  - Add testing guide (`docs/testing.md`)
  - Dead code removed in places (code that could never be reached)

## Test results

  | Metric | Result |
  |--------|--------|
  | Unit tests | 155/155 passed (11 files) |
  | Integration tests | 10/10 passed |
  | Lint (ESLint) | Clean |
  | Statements | 99.27% |
  | Branches | 95.37% |
  | Functions | 100% |
  | Lines | 99.26% |

  > `interactive-config.js` is excluded from coverage — it handles interactive terminal prompts that are not suitable for automated testing.

## Test plan
  - [x] `npm test` — all 155 unit tests pass
  - [x] `npm run test:coverage` — exceeds 80% target across all metrics
  - [x] `npm run test:integration` — all 10 integration tests pass (Cerebras, OpenRouter, fallback, edit path, context files, error handling)
  - [x] `npm run lint` — clean

All functionality has been hand tested in Claude Code. 